### PR TITLE
Products visibility bug

### DIFF
--- a/crossselling.php
+++ b/crossselling.php
@@ -174,6 +174,7 @@ class CrossSelling extends Module
                 AND od.product_id NOT IN ('.$list_product_ids.')
                 AND i.cover = 1
                 AND product_shop.active = 1
+                AND p.visibility IN ("both", "catalog") 
                 '.(Group::isFeatureActive() ? $sql_groups_where : '').'
                 ORDER BY RAND()
                 LIMIT '.(int)Configuration::get('CROSSSELLING_NBR'));


### PR DESCRIPTION
As reported on https://forum.thirtybees.com/topic/1973/block-cross-selling-v2-0-1-displays-products-on-frontend-that-are-flagged-visibility-nowhere/

Tested and working fine. Must clear cache before checking.
Please review and merge.